### PR TITLE
添加针对JsonString长度的判断，当长度大于12000时，循环逐行打印，小于12000时，直接打印

### DIFF
--- a/library/src/main/java/com/socks/library/klog/JsonLog.java
+++ b/library/src/main/java/com/socks/library/klog/JsonLog.java
@@ -33,10 +33,14 @@ public class JsonLog {
         }
 
         Util.printLine(tag, true);
-        message = headString + KLog.LINE_SEPARATOR + message;
-        String[] lines = message.split(KLog.LINE_SEPARATOR);
-        for (String line : lines) {
-            Log.d(tag, "║ " + line);
+        if (message.length() > 12000) {
+            message = headString + KLog.LINE_SEPARATOR + message;
+            String[] lines = message.split(KLog.LINE_SEPARATOR);
+            for (String line : lines) {
+                Log.d(tag, "║ " + line);
+            }
+        } else {
+            Log.d(tag, "║ " + message);
         }
         Util.printLine(tag, false);
     }


### PR DESCRIPTION
根据我个人测试，JsonString长度超过12000的时候打印不全。如果有错误请指正。